### PR TITLE
Add JobSize factor calculation optimization

### DIFF
--- a/contribs/perlapi/libslurm/perl/conf.c
+++ b/contribs/perlapi/libslurm/perl/conf.c
@@ -252,6 +252,9 @@ int slurm_ctl_conf_to_hv(slurm_conf_t *conf, HV *hv)
 	STORE_FIELD(hv, conf, priority_weight_part, uint32_t);
 	STORE_FIELD(hv, conf, priority_weight_qos, uint32_t);
 	STORE_FIELD(hv, conf, priority_weight_tres, charp);
+#ifdef __METASTACK_PRIORITY_JOBSIZE
+	STORE_FIELD(hv, conf, priority_jobsize_maxvalue, charp);
+#endif	
 	STORE_FIELD(hv, conf, private_data, uint16_t);
 
 	if (conf->proctrack_type)
@@ -562,6 +565,9 @@ int hv_to_slurm_ctl_conf(HV *hv, slurm_conf_t *conf)
 	FETCH_FIELD(hv, conf, priority_weight_part, uint32_t, TRUE);
 	FETCH_FIELD(hv, conf, priority_weight_qos, uint32_t, FALSE);
 	FETCH_FIELD(hv, conf, priority_weight_tres, charp, FALSE);
+#ifdef __METASTACK_PRIORITY_JOBSIZE
+	FETCH_FIELD(hv, conf, priority_jobsize_maxvalue, charp, FALSE);
+#endif
 	FETCH_FIELD(hv, conf, private_data, uint16_t, TRUE);
 	FETCH_FIELD(hv, conf, proctrack_type, charp, FALSE);
 	FETCH_FIELD(hv, conf, prolog, charp, FALSE);

--- a/doc/man/man5/slurm.conf.5
+++ b/doc/man/man5/slurm.conf.5
@@ -3028,6 +3028,30 @@ The default values are 0.
 .IP
 
 .TP
+\fBPriorityJobSizeMaxValue\fR
+A comma\-separated list of JobSize calculation types and maximum values, 
+used to customize the maximum number of CPU cores and nodes when calculating job size priority.
+.br
+The CPU must be set; if only the node is set, the configuration item will not take effect.
+
+.IP
+.nf
+e.g.
+PriorityJobSizeMaxValue=cpu=128
+PriorityJobSizeMaxValue=cpu=128,node=10
+.fi
+
+PriorityJobSizeMaxValue=cpu=128 means that the job's size is measured based 
+on the number of CPU cores. 
+PriorityJobSizeMaxValue=cpu=128,node=10 means that the job's size is measured 
+based on both the number of CPU cores and the number of nodes.
+.br
+Once this configuration is enabled, the job size priority calculation will use the customized maximum CPU cores and nodes. 
+If this configuration is not enabled, the job size priority will be calculated based on the total number of CPU cores and nodes in the cluster. 
+The default value is null.
+.IP
+
+.TP
 \fBPrivateData\fR
 This controls what type of information is hidden from regular users.
 By default, all information is visible to all users.

--- a/slurm/slurm.h
+++ b/slurm/slurm.h
@@ -368,6 +368,11 @@ typedef struct sbcast_cred sbcast_cred_t;		/* opaque data type */
 #ifndef __METASTACK_OPT_MSG_OUTPUT
 #define __METASTACK_OPT_MSG_OUTPUT
 #endif
+
+/* Macro definitions that control the size of Jobsize */
+#ifndef __METASTACK_PRIORITY_JOBSIZE
+#define __METASTACK_PRIORITY_JOBSIZE
+#endif
 /*****************************************************************************\
  *	DEFINITIONS FOR INPUT VALUES
 \*****************************************************************************/
@@ -3237,6 +3242,9 @@ typedef struct {
 	uint32_t priority_weight_part; /* weight for Partition factor */
 	uint32_t priority_weight_qos; /* weight for QOS factor */
 	char    *priority_weight_tres; /* weights (str) for different TRES' */
+#ifdef __METASTACK_PRIORITY_JOBSIZE
+	char    *priority_jobsize_maxvalue; /* maxvalue (str) for JobSize' */
+#endif
 	uint16_t private_data;	/* block viewing of information,
 				 * see PRIVATE_DATA_* */
 	char *proctrack_type;	/* process tracking plugin type */

--- a/src/api/config_info.c
+++ b/src/api/config_info.c
@@ -1514,6 +1514,14 @@ extern void *slurm_ctl_conf_2_key_pairs(slurm_conf_t *slurm_ctl_conf_ptr)
 		key_pair->value =
 			xstrdup(slurm_ctl_conf_ptr->priority_weight_tres);
 		list_append(ret_list, key_pair);
+
+#ifdef __METASTACK_PRIORITY_JOBSIZE
+		key_pair = xmalloc(sizeof(config_key_pair_t));
+		key_pair->name = xstrdup("PriorityJobSizeMaxValue");
+		key_pair->value =
+			xstrdup(slurm_ctl_conf_ptr->priority_jobsize_maxvalue);
+		list_append(ret_list, key_pair);
+#endif		
 	}
 
 

--- a/src/common/slurm_protocol_api.h
+++ b/src/common/slurm_protocol_api.h
@@ -112,6 +112,17 @@ int slurm_get_auth_ttl(void);
  */
 double *slurm_get_tres_weight_array(char *weights_str, int tres_cnt, bool fail);
 
+/* slurm_get_jobsize_maxvalue
+ * IN jobsize_maxvalue_str - string of jobsize_maxvalue to be parsed.
+ * IN tres_cnt - count of how many tres' are on the system (e.g.
+ * 		slurmctld_tres_cnt).
+ * IN fail - whether to fatal or not if there are parsing errors.
+ *  * RET double* of jobsize maxvalue.
+ */
+#ifdef __METASTACK_PRIORITY_JOBSIZE
+double *slurm_get_jobsize_maxvalue(char *jobsize_maxvalue_str, int tres_cnt, bool fail);
+#endif
+
 /* slurm_get_stepd_loc
  * get path to the slurmstepd
  * RET char * - absolute path to the slurmstepd, MUST be xfreed by caller

--- a/src/common/slurm_protocol_pack.c
+++ b/src/common/slurm_protocol_pack.c
@@ -4840,6 +4840,9 @@ _pack_slurm_ctl_conf_msg(slurm_ctl_conf_info_msg_t * build_ptr, buf_t *buffer,
             pack_key_pair_list(build_ptr->rl_users, protocol_version,
                             buffer);							
 #endif
+#ifdef __METASTACK_PRIORITY_JOBSIZE
+            packstr(build_ptr->priority_jobsize_maxvalue, buffer);
+#endif
         } else if (protocol_version >= META_2_1_PROTOCOL_VERSION) {
             pack_time(build_ptr->last_update, buffer);
 

--- a/src/slurmctld/proc_req.c
+++ b/src/slurmctld/proc_req.c
@@ -488,6 +488,9 @@ static void _fill_ctld_conf(slurm_conf_t *conf_ptr)
 	conf_ptr->priority_weight_part= conf->priority_weight_part;
 	conf_ptr->priority_weight_qos = conf->priority_weight_qos;
 	conf_ptr->priority_weight_tres = xstrdup(conf->priority_weight_tres);
+#ifdef __METASTACK_PRIORITY_JOBSIZE
+	conf_ptr->priority_jobsize_maxvalue = xstrdup(conf->priority_jobsize_maxvalue);
+#endif	
 
 	conf_ptr->private_data        = conf->private_data;
 	conf_ptr->proctrack_type      = xstrdup(conf->proctrack_type);


### PR DESCRIPTION
JobSize Calculation Optimization: The JobSize priority value can be calculated based on the number of CPU cores requested by the job, or based on both the number of CPU cores and the number of nodes. Additionally, the maximum number of CPU cores and nodes used to evaluate the job size can be manually configured.