### PR TITLE
Slurmctld Load Gres

### DIFF
--- a/contribs/perlapi/libslurm/perl/conf.c
+++ b/contribs/perlapi/libslurm/perl/conf.c
@@ -339,6 +339,9 @@ int slurm_ctl_conf_to_hv(slurm_conf_t *conf, HV *hv)
 	STORE_FIELD(hv, conf, slurmctld_port_count, uint16_t);
 	STORE_FIELD(hv, conf, slurmctld_timeout, uint16_t);
 
+#ifdef  __METASTACK_OPT_GRES_CONFIG
+	STORE_FIELD(hv, conf, slurmctld_load_gres, uint16_t);
+#endif
 	STORE_FIELD(hv, conf, slurmd_debug, uint16_t);
 	if (conf->slurmd_logfile)
 		STORE_FIELD(hv, conf, slurmd_logfile, charp);
@@ -612,6 +615,9 @@ int hv_to_slurm_ctl_conf(HV *hv, slurm_conf_t *conf)
 	FETCH_FIELD(hv, conf, slurmctld_port_count, uint16_t, TRUE);
 	FETCH_FIELD(hv, conf, slurmctld_timeout, uint16_t, TRUE);
 
+#ifdef  __METASTACK_OPT_GRES_CONFIG
+	FETCH_FIELD(hv, conf, slurmctld_load_gres, uint16_t, TRUE);
+#endif
 	FETCH_FIELD(hv, conf, slurmd_debug, uint16_t, TRUE);
 	FETCH_FIELD(hv, conf, slurmd_logfile, charp, FALSE);
 	FETCH_FIELD(hv, conf, slurmd_pidfile, charp, FALSE);

--- a/doc/man/man5/slurm.conf.5
+++ b/doc/man/man5/slurm.conf.5
@@ -5311,6 +5311,18 @@ and "StandardError=null" to the respective service files or override files.
 .IP
 
 .TP
+\fBSlurmctldLoadGres\fR
+Specifies whether Slurmctld should load the GRES configuration when starting up. 
+If set to "Yes", regardless of whether the Slurm daemon service is running, 
+the management node will preload all nodes' GRES configurations when starting 
+Slurmctld service, which can effectively prevent the submission of jobs that do
+not meet the core-to-GPU ratio requirements.
+Configuration method:
+SlurmctldLoadGres=Yes  enables Slurmctld to read GRES configuration functionality.
+SlurmctldLoadGres=No  disables Slurmctld to read GRES configuration functionality.
+.IP
+
+.TP
 \fBSlurmdTimeout\fR
 The interval, in seconds, that the Slurm controller waits for \fBslurmd\fR
 to respond before configuring that node's state to DOWN.

--- a/slurm/slurm.h
+++ b/slurm/slurm.h
@@ -385,6 +385,10 @@ typedef struct sbcast_cred sbcast_cred_t;		/* opaque data type */
 #define __METASTACK_NEW_MAIN_SCHED_PLANNED
 #endif
 
+#ifndef __METASTACK_OPT_GRES_CONFIG
+#define __METASTACK_OPT_GRES_CONFIG
+#endif
+
 /* Macro definitions that control the size of Jobsize */
 #ifndef __METASTACK_PRIORITY_JOBSIZE
 #define __METASTACK_PRIORITY_JOBSIZE
@@ -3336,6 +3340,9 @@ typedef struct {
 	uint16_t slurmctld_timeout;/* seconds that backup controller waits
 				    * on non-responding primarly controller */
 	char *slurmctld_params;	/* SlurmctldParameters */
+#ifdef  __METASTACK_OPT_GRES_CONFIG
+	uint16_t slurmctld_load_gres; /* slurmctld load gres */
+#endif
 	uint16_t slurmd_debug;	/* slurmd logging level */
 	char *slurmd_logfile;	/* where slurmd error log gets written */
 	char *slurmd_params;	/* SlurmdParameters */

--- a/src/api/config_info.c
+++ b/src/api/config_info.c
@@ -927,6 +927,13 @@ extern void *slurm_ctl_conf_2_key_pairs(slurm_conf_t *slurm_ctl_conf_ptr)
 	key_pair->value = xstrdup(
 		(slurm_ctl_conf_ptr->conf_flags & CTL_CONF_HCN) ? "Yes" : "No");
 #endif
+#ifdef __METASTACK_OPT_GRES_CONFIG
+	key_pair = xmalloc(sizeof(config_key_pair_t));
+	key_pair->name = xstrdup("SlurmctldLoadGres");
+	key_pair->value = xstrdup(
+		slurm_ctl_conf_ptr->slurmctld_load_gres ? "Yes" : "No");
+	list_append(ret_list, key_pair);
+#endif
 	key_pair = xmalloc(sizeof(config_key_pair_t));
 	key_pair->name = xstrdup("EioTimeout");
 	snprintf(tmp_str, sizeof(tmp_str), "%u",

--- a/src/common/gres.h
+++ b/src/common/gres.h
@@ -472,6 +472,13 @@ extern int gres_g_node_config_load(uint32_t cpu_cnt, char *node_name,
 				   void *xcpuinfo_abs_to_mac,
 				   void *xcpuinfo_mac_to_abs);
 
+#ifdef  __METASTACK_OPT_GRES_CONFIG
+extern int gres_g_node_config_loadgres(uint32_t cpu_cnt, char *node_name,
+                   List gres_list,
+                   void *xcpuinfo_abs_to_mac,
+                   void *xcpuinfo_mac_to_abs, parsed_line_t *parsed_lines, int max_lines);
+#endif
+
 /*
  * Set GRES devices as allocated or not for a particular job
  * IN gres_list - allocated gres devices
@@ -1207,6 +1214,10 @@ extern bool gres_use_busy_dev(gres_state_t *gres_state_node,
  * to conf_includes_list for configless files push.
  */
 extern void gres_parse_config_dummy(void);
+
+#ifdef  __METASTACK_OPT_GRES_CONFIG
+extern s_p_hashtbl_t *gres_parse_config_file(char *gres_conf_file, parsed_line_t *parsed_lines, int max_parsed_lines, int *num_parsed_lines);
+#endif
 
 #ifdef __METASTACK_OPT_CACHE_QUERY
 

--- a/src/common/parse_config.h
+++ b/src/common/parse_config.h
@@ -287,6 +287,20 @@ typedef enum slurm_parser_operator {
 	S_P_OPERATOR_AVG
 } slurm_parser_operator_t;
 
+#ifdef __METASTACK_OPT_GRES_CONFIG
+typedef struct {
+    char *key;
+    char *value;
+    char *new_leftover;
+    slurm_parser_operator_t op;
+    hostlist_t hostlist;
+	s_p_hashtbl_t *hashtbl;
+} parsed_line_t;
+
+extern parsed_line_t *parsed_lines;
+extern int current_line_index;
+#endif
+
 typedef struct conf_file_options {
 	char *key;
 	slurm_parser_enum_t type;
@@ -311,7 +325,13 @@ void s_p_hashtbl_destroy(s_p_hashtbl_t *hashtbl);
  */
 int s_p_parse_file(s_p_hashtbl_t *hashtbl, uint32_t *hash_val, char *filename,
 		   bool ignore_new, char *last_ancestor);
+#ifdef __METASTACK_OPT_GRES_CONFIG
+int s_p_parse_gres_file(s_p_hashtbl_t *hashtbl, uint32_t *hash_val, char *filename,
+		   bool ignore_new, char *last_ancestor, parsed_line_t *parsed_lines, int max_parsed_lines, int *num_parsed_lines);
 
+int s_p_parse_file_gres(s_p_hashtbl_t *hashtbl, char *filename,
+		   bool ignore_new, parsed_line_t *parsed_lines, int max_lines, char *gres_node_name);
+#endif
 /* Returns SLURM_SUCCESS if buffer was opened and parse correctly.
  * buffer must be a valid buf_t buffer only containing strings. The parsing
  * stops at the first non string content extracted.

--- a/src/common/read_config.c
+++ b/src/common/read_config.c
@@ -438,6 +438,9 @@ s_p_options_t slurm_conf_options[] = {
 	{"SlurmctldSyslogDebug", S_P_STRING},
 	{"SlurmctldTimeout", S_P_UINT16},
 	{"SlurmctldParameters", S_P_STRING},
+#ifdef  __METASTACK_OPT_GRES_CONFIG
+	{"SlurmctldLoadGres", S_P_BOOLEAN},
+#endif
 	{"SlurmdDebug", S_P_STRING},
 	{"SlurmdLogFile", S_P_STRING},
 	{"SlurmdParameters", S_P_STRING},
@@ -4697,6 +4700,12 @@ static int _validate_and_set_defaults(slurm_conf_t *conf,
 #ifdef __METASTACK_NEW_STATE_TO_NHC
 	if (s_p_get_boolean(&truth, "HealthCheckCarryNode", hashtbl) && truth)
 		conf->conf_flags |= CTL_CONF_HCN;
+#endif
+#ifdef __METASTACK_OPT_GRES_CONFIG
+	if (s_p_get_boolean(&truth, "SlurmctldLoadGres", hashtbl) && truth)
+		conf->slurmctld_load_gres = 1;
+	else
+		conf->slurmctld_load_gres = 0;
 #endif
 	if (s_p_get_string(&temp_str,
 			   "EnforcePartLimits", hashtbl)) {

--- a/src/common/slurm_protocol_pack.c
+++ b/src/common/slurm_protocol_pack.c
@@ -4432,7 +4432,331 @@ _pack_slurm_ctl_conf_msg(slurm_ctl_conf_info_msg_t * build_ptr, buf_t *buffer,
 	uint32_t count = NO_VAL;
 #ifdef __META_PROTOCOL
     if (protocol_version >= SLURM_22_05_PROTOCOL_VERSION) {
-        if (protocol_version >= META_2_2_PROTOCOL_VERSION) {
+        if (protocol_version >= META_2_3_PROTOCOL_VERSION) {
+                        pack_time(build_ptr->last_update, buffer);
+
+            pack16(build_ptr->accounting_storage_enforce, buffer);
+            packstr(build_ptr->accounting_storage_backup_host, buffer);
+            packstr(build_ptr->accounting_storage_host, buffer);
+            packstr(build_ptr->accounting_storage_ext_host, buffer);
+            packstr(build_ptr->accounting_storage_params, buffer);
+            pack16(build_ptr->accounting_storage_port, buffer);
+            packstr(build_ptr->accounting_storage_tres, buffer);
+            packstr(build_ptr->accounting_storage_type, buffer);
+            packstr(build_ptr->accounting_storage_user, buffer);
+
+            if (build_ptr->acct_gather_conf)
+                count = list_count(build_ptr->acct_gather_conf);
+            else
+                count = NO_VAL;
+
+            if (list_find_first(build_ptr->acct_gather_conf,
+                                _list_find_conf_entry,
+                                "ProfileInfluxDBPass"))
+                count--;
+            if (list_find_first(build_ptr->acct_gather_conf,
+                                _list_find_conf_entry,
+                                "ProfileInfluxDBUser"))
+                count--;
+
+            pack32(count, buffer);
+            if (count && (count != NO_VAL)) {
+                ListIterator itr = list_iterator_create(
+                    (List)build_ptr->acct_gather_conf);
+                config_key_pair_t *key_pair = NULL;
+                while ((key_pair = list_next(itr))) {
+                    if (xstrcasecmp(key_pair->name,
+                                    "ProfileInfluxDBPass") &&
+                        xstrcasecmp(key_pair->name,
+                                    "ProfileInfluxDBUser"))
+                        pack_config_key_pair(key_pair,
+                                            protocol_version,
+                                            buffer);
+                }
+                list_iterator_destroy(itr);
+            }
+
+            packstr(build_ptr->acct_gather_energy_type, buffer);
+            packstr(build_ptr->acct_gather_filesystem_type, buffer);
+            packstr(build_ptr->acct_gather_interconnect_type, buffer);
+            pack16(build_ptr->acct_gather_node_freq, buffer);
+            packstr(build_ptr->acct_gather_profile_type, buffer);
+
+            packstr(build_ptr->authalttypes, buffer);
+            packstr(build_ptr->authalt_params, buffer);
+            packstr(build_ptr->authinfo, buffer);
+            packstr(build_ptr->authtype, buffer);
+
+            pack16(build_ptr->batch_start_timeout, buffer);
+            pack_time(build_ptr->boot_time, buffer);
+            packstr(build_ptr->bb_type, buffer);
+            packstr(build_ptr->bcast_exclude, buffer);
+            packstr(build_ptr->bcast_parameters, buffer);
+
+            pack_key_pair_list(build_ptr->cgroup_conf, protocol_version,
+                            buffer);
+            packstr(build_ptr->cli_filter_plugins, buffer);
+            packstr(build_ptr->cluster_name, buffer);
+            packstr(build_ptr->comm_params, buffer);
+            pack16(build_ptr->complete_wait, buffer);
+            pack32(build_ptr->conf_flags, buffer);
+            packstr_array(build_ptr->control_addr,
+                        build_ptr->control_cnt, buffer);
+            packstr_array(build_ptr->control_machine,
+                        build_ptr->control_cnt, buffer);
+            packstr(build_ptr->core_spec_plugin, buffer);
+            pack32(build_ptr->cpu_freq_def, buffer);
+            pack32(build_ptr->cpu_freq_govs, buffer);
+            packstr(build_ptr->cred_type, buffer);
+
+            pack64(build_ptr->def_mem_per_cpu, buffer);
+            pack64(build_ptr->debug_flags, buffer);
+            packstr(build_ptr->dependency_params, buffer);
+
+            pack16(build_ptr->eio_timeout, buffer);
+            pack16(build_ptr->enforce_part_limits, buffer);
+            packstr(build_ptr->epilog, buffer);
+            pack32(build_ptr->epilog_msg_time, buffer);
+            packstr(build_ptr->epilog_slurmctld, buffer);
+
+            pack_key_pair_list(build_ptr->ext_sensors_conf,
+                            protocol_version, buffer);
+
+            packstr(build_ptr->ext_sensors_type, buffer);
+            pack16(build_ptr->ext_sensors_freq, buffer);
+
+            packstr(build_ptr->fed_params, buffer);
+            pack32(build_ptr->first_job_id, buffer);
+            pack16(build_ptr->fs_dampening_factor, buffer);
+
+            pack16(build_ptr->get_env_timeout, buffer);
+            packstr(build_ptr->gres_plugins, buffer);
+            pack16(build_ptr->group_time, buffer);
+            pack16(build_ptr->group_force, buffer);
+            packstr(build_ptr->gpu_freq_def, buffer);
+
+            pack32(build_ptr->hash_val, buffer);
+
+            pack16(build_ptr->health_check_interval, buffer);
+            pack16(build_ptr->health_check_node_state, buffer);
+            packstr(build_ptr->health_check_program, buffer);
+
+            pack16(build_ptr->inactive_limit, buffer);
+            packstr(build_ptr->interactive_step_opts, buffer);
+
+            packstr(build_ptr->job_acct_gather_freq, buffer);
+            packstr(build_ptr->job_acct_gather_type, buffer);
+            packstr(build_ptr->job_acct_gather_params, buffer);
+
+            packstr(build_ptr->job_comp_host, buffer);
+            packstr(build_ptr->job_comp_loc, buffer);
+            packstr(build_ptr->job_comp_params, buffer);
+            pack32((uint32_t)build_ptr->job_comp_port, buffer);
+            packstr(build_ptr->job_comp_type, buffer);
+            packstr(build_ptr->job_comp_user, buffer);
+            packstr(build_ptr->job_container_plugin, buffer);
+
+            packstr(build_ptr->job_credential_private_key, buffer);
+            packstr(build_ptr->job_credential_public_certificate, buffer);
+            (void)slurm_pack_list(build_ptr->job_defaults_list,
+                                job_defaults_pack, buffer,
+                                protocol_version);
+            pack16(build_ptr->job_file_append, buffer);
+            pack16(build_ptr->job_requeue, buffer);
+            packstr(build_ptr->job_submit_plugins, buffer);
+
+            pack16(build_ptr->kill_on_bad_exit, buffer);
+            pack16(build_ptr->kill_wait, buffer);
+
+            packstr(build_ptr->launch_params, buffer);
+            packstr(build_ptr->launch_type, buffer);
+            packstr(build_ptr->licenses, buffer);
+            pack16(build_ptr->log_fmt, buffer);
+
+            pack32(build_ptr->max_array_sz, buffer);
+            pack32(build_ptr->max_dbd_msgs, buffer);
+            packstr(build_ptr->mail_domain, buffer);
+            packstr(build_ptr->mail_prog, buffer);
+            pack32(build_ptr->max_job_cnt, buffer);
+            pack32(build_ptr->max_job_id, buffer);
+            pack64(build_ptr->max_mem_per_cpu, buffer);
+            pack32(build_ptr->max_node_cnt, buffer);
+            pack32(build_ptr->max_step_cnt, buffer);
+            pack16(build_ptr->max_tasks_per_node, buffer);
+
+            packstr(build_ptr->mcs_plugin, buffer);
+            packstr(build_ptr->mcs_plugin_params, buffer);
+
+            pack32(build_ptr->min_job_age, buffer);
+            pack_key_pair_list(
+                build_ptr->mpi_conf, protocol_version, buffer);
+            packstr(build_ptr->mpi_default, buffer);
+            packstr(build_ptr->mpi_params, buffer);
+            pack16(build_ptr->msg_timeout, buffer);
+
+            pack32(build_ptr->next_job_id, buffer);
+
+            pack_config_plugin_params_list(build_ptr->node_features_conf,
+                                        protocol_version, buffer);
+
+            packstr(build_ptr->node_features_plugins, buffer);
+            packstr(build_ptr->node_prefix, buffer);
+
+            pack16(build_ptr->over_time_limit, buffer);
+
+            packstr(build_ptr->plugindir, buffer);
+            packstr(build_ptr->plugstack, buffer);
+            packstr(build_ptr->power_parameters, buffer);
+            packstr(build_ptr->power_plugin, buffer);
+            pack16(build_ptr->preempt_mode, buffer);
+            packstr(build_ptr->preempt_type, buffer);
+            pack32(build_ptr->preempt_exempt_time, buffer);
+            packstr(build_ptr->prep_params, buffer);
+            packstr(build_ptr->prep_plugins, buffer);
+
+            pack32(build_ptr->priority_decay_hl, buffer);
+            pack32(build_ptr->priority_calc_period, buffer);
+            pack16(build_ptr->priority_favor_small, buffer);
+            pack16(build_ptr->priority_flags, buffer);
+            pack32(build_ptr->priority_max_age, buffer);
+            packstr(build_ptr->priority_params, buffer);
+            pack16(build_ptr->priority_reset_period, buffer);
+            packstr(build_ptr->priority_type, buffer);
+            pack32(build_ptr->priority_weight_age, buffer);
+            pack32(build_ptr->priority_weight_assoc, buffer);
+            pack32(build_ptr->priority_weight_fs, buffer);
+            pack32(build_ptr->priority_weight_js, buffer);
+            pack32(build_ptr->priority_weight_part, buffer);
+            pack32(build_ptr->priority_weight_qos, buffer);
+            packstr(build_ptr->priority_weight_tres, buffer);
+
+            pack16(build_ptr->private_data, buffer);
+            packstr(build_ptr->proctrack_type, buffer);
+            packstr(build_ptr->prolog, buffer);
+            pack16(build_ptr->prolog_epilog_timeout, buffer);
+            packstr(build_ptr->prolog_slurmctld, buffer);
+            pack16(build_ptr->prolog_flags, buffer);
+            pack16(build_ptr->propagate_prio_process, buffer);
+            packstr(build_ptr->propagate_rlimits, buffer);
+            packstr(build_ptr->propagate_rlimits_except, buffer);
+
+            packstr(build_ptr->reboot_program, buffer);
+            pack16(build_ptr->reconfig_flags, buffer);
+            packstr(build_ptr->requeue_exit, buffer);
+            packstr(build_ptr->requeue_exit_hold, buffer);
+            packstr(build_ptr->resume_fail_program, buffer);
+            packstr(build_ptr->resume_program, buffer);
+            pack16(build_ptr->resume_rate, buffer);
+            pack16(build_ptr->resume_timeout, buffer);
+            packstr(build_ptr->resv_epilog, buffer);
+            pack16(build_ptr->resv_over_run, buffer);
+            packstr(build_ptr->resv_prolog, buffer);
+            pack16(build_ptr->ret2service, buffer);
+
+            packstr(build_ptr->route_plugin, buffer);
+            packstr(build_ptr->sched_params, buffer);
+            packstr(build_ptr->sched_logfile, buffer);
+            pack16(build_ptr->sched_log_level, buffer);
+            pack16(build_ptr->sched_time_slice, buffer);
+            packstr(build_ptr->schedtype, buffer);
+            packstr(build_ptr->scron_params, buffer);
+            packstr(build_ptr->select_type, buffer);
+
+            pack_key_pair_list(build_ptr->select_conf_key_pairs,
+                            protocol_version, buffer);
+
+            pack16(build_ptr->select_type_param, buffer);
+
+            packstr(build_ptr->slurm_conf, buffer);
+            pack32(build_ptr->slurm_user_id, buffer);
+            packstr(build_ptr->slurm_user_name, buffer);
+            pack32(build_ptr->slurmd_user_id, buffer);
+            packstr(build_ptr->slurmd_user_name, buffer);
+
+            packstr(build_ptr->slurmctld_addr, buffer);
+            pack16(build_ptr->slurmctld_debug, buffer);
+            packstr(build_ptr->slurmctld_logfile, buffer);
+            packstr(build_ptr->slurmctld_params, buffer);
+            packstr(build_ptr->slurmctld_pidfile, buffer);
+            packstr(build_ptr->slurmctld_plugstack, buffer);
+            pack_config_plugin_params_list(
+                build_ptr->slurmctld_plugstack_conf,
+                protocol_version,
+                buffer);
+            pack32(build_ptr->slurmctld_port, buffer);
+            pack16(build_ptr->slurmctld_port_count, buffer);
+            packstr(build_ptr->slurmctld_primary_off_prog, buffer);
+            packstr(build_ptr->slurmctld_primary_on_prog, buffer);
+            pack16(build_ptr->slurmctld_syslog_debug, buffer);
+            pack16(build_ptr->slurmctld_timeout, buffer);
+
+            pack16(build_ptr->slurmd_debug, buffer);
+            packstr(build_ptr->slurmd_logfile, buffer);
+            packstr(build_ptr->slurmd_params, buffer);
+            packstr(build_ptr->slurmd_pidfile, buffer);
+            pack32(build_ptr->slurmd_port, buffer);
+
+            packstr(build_ptr->slurmd_spooldir, buffer);
+            pack16(build_ptr->slurmd_syslog_debug, buffer);
+            pack16(build_ptr->slurmd_timeout, buffer);
+            packstr(build_ptr->srun_epilog, buffer);
+            pack16(build_ptr->srun_port_range[0], buffer);
+            pack16(build_ptr->srun_port_range[1], buffer);
+            packstr(build_ptr->srun_prolog, buffer);
+            packstr(build_ptr->state_save_location, buffer);
+            packstr(build_ptr->suspend_exc_nodes, buffer);
+            packstr(build_ptr->suspend_exc_parts, buffer);
+
+            packstr(build_ptr->suspend_program, buffer);
+            pack16(build_ptr->suspend_rate, buffer);
+            pack32(build_ptr->suspend_time, buffer);
+            pack16(build_ptr->suspend_timeout, buffer);
+            packstr(build_ptr->switch_param, buffer);
+            packstr(build_ptr->switch_type, buffer);
+
+            packstr(build_ptr->task_epilog, buffer);
+            packstr(build_ptr->task_prolog, buffer);
+            packstr(build_ptr->task_plugin, buffer);
+            pack32(build_ptr->task_plugin_param, buffer);
+            pack16(build_ptr->tcp_timeout, buffer);
+            packstr(build_ptr->tmp_fs, buffer);
+            packstr(build_ptr->topology_param, buffer);
+            packstr(build_ptr->topology_plugin, buffer);
+            pack16(build_ptr->tree_width, buffer);
+
+            packstr(build_ptr->unkillable_program, buffer);
+            pack16(build_ptr->unkillable_timeout, buffer);
+            packstr(build_ptr->version, buffer);
+            pack16(build_ptr->vsize_factor, buffer);
+
+            pack16(build_ptr->wait_time, buffer);
+            packstr(build_ptr->x11_params, buffer);
+#ifdef __METASTACK_NEW_SUSPEND_KEEP_IDLE
+            pack32(build_ptr->suspend_idle_def, buffer);
+#endif
+#ifdef __METASTACK_OPT_CACHE_QUERY
+            pack16(build_ptr->cachedup_interval, buffer);
+            pack16(build_ptr->cache_query, buffer);
+            pack32(build_ptr->query_port, buffer);
+            pack16(build_ptr->query_port_count, buffer);
+            pack16(build_ptr->cachedup_abs_realtime, buffer);
+#endif
+#ifdef __METASTACK_OPT_MSG_OUTPUT
+            packstr(build_ptr->extra_msg_file, buffer);
+#endif
+#ifdef __METASTACK_NEW_RPC_RATE_LIMIT
+            pack_key_pair_list(build_ptr->rl_config, protocol_version,
+                            buffer);
+            pack_key_pair_list(build_ptr->rl_users, protocol_version,
+                            buffer);							
+#endif
+#ifdef __METASTACK_PRIORITY_JOBSIZE
+            packstr(build_ptr->priority_jobsize_maxvalue, buffer);
+#endif	
+#ifdef __METASTACK_OPT_GRES_CONFIG
+			pack16(build_ptr->slurmctld_load_gres, buffer);
+#endif
+        } else if (protocol_version >= META_2_2_PROTOCOL_VERSION) {
                         pack_time(build_ptr->last_update, buffer);
 
             pack16(build_ptr->accounting_storage_enforce, buffer);
@@ -6285,7 +6609,446 @@ _unpack_slurm_ctl_conf_msg(slurm_ctl_conf_info_msg_t **build_buffer_ptr,
 
 #ifdef __META_PROTOCOL
     if (protocol_version >= SLURM_22_05_PROTOCOL_VERSION) {
-        if (protocol_version >= META_2_2_PROTOCOL_VERSION) {
+        if (protocol_version >= META_2_3_PROTOCOL_VERSION) {
+                        safe_unpack_time(&build_ptr->last_update, buffer);
+
+            safe_unpack16(&build_ptr->accounting_storage_enforce, buffer);
+            safe_unpackstr_xmalloc(
+                &build_ptr->accounting_storage_backup_host,
+                &uint32_tmp, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->accounting_storage_host,
+                                &uint32_tmp, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->accounting_storage_ext_host,
+                                &uint32_tmp, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->accounting_storage_params,
+                                &uint32_tmp, buffer);
+            safe_unpack16(&build_ptr->accounting_storage_port, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->accounting_storage_tres,
+                                &uint32_tmp, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->accounting_storage_type,
+                                &uint32_tmp, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->accounting_storage_user,
+                                &uint32_tmp, buffer);
+
+            if (unpack_key_pair_list(&build_ptr->acct_gather_conf,
+                                    protocol_version, buffer)
+                != SLURM_SUCCESS)
+                goto unpack_error;
+
+            safe_unpackstr_xmalloc(&build_ptr->acct_gather_energy_type,
+                                &uint32_tmp, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->acct_gather_filesystem_type,
+                                &uint32_tmp, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->acct_gather_interconnect_type,
+                                &uint32_tmp, buffer);
+            safe_unpack16(&build_ptr->acct_gather_node_freq, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->acct_gather_profile_type,
+                                &uint32_tmp, buffer);
+
+            safe_unpackstr_xmalloc(&build_ptr->authalttypes,
+                        &uint32_tmp, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->authalt_params,
+                        &uint32_tmp, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->authinfo,
+                                &uint32_tmp, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->authtype,
+                                &uint32_tmp, buffer);
+
+            safe_unpack16(&build_ptr->batch_start_timeout, buffer);
+            safe_unpack_time(&build_ptr->boot_time, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->bb_type,
+                                &uint32_tmp, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->bcast_exclude,
+                                &uint32_tmp, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->bcast_parameters,
+                                &uint32_tmp, buffer);
+
+            if (unpack_key_pair_list(&build_ptr->cgroup_conf,
+                                    protocol_version, buffer)
+                != SLURM_SUCCESS)
+                goto unpack_error;
+            safe_unpackstr_xmalloc(&build_ptr->cli_filter_plugins,
+                                &uint32_tmp, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->cluster_name,
+                                &uint32_tmp, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->comm_params,
+                                &uint32_tmp, buffer);
+            safe_unpack16(&build_ptr->complete_wait, buffer);
+            safe_unpack32(&build_ptr->conf_flags, buffer);
+            safe_unpackstr_array(&build_ptr->control_addr,
+                                &build_ptr->control_cnt, buffer);
+            safe_unpackstr_array(&build_ptr->control_machine,
+                                &uint32_tmp, buffer);
+            if (build_ptr->control_cnt != uint32_tmp)
+                goto unpack_error;
+            safe_unpackstr_xmalloc(&build_ptr->core_spec_plugin,
+                                &uint32_tmp, buffer);
+            safe_unpack32(&build_ptr->cpu_freq_def, buffer);
+            safe_unpack32(&build_ptr->cpu_freq_govs, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->cred_type, &uint32_tmp,
+                                buffer);
+
+            safe_unpack64(&build_ptr->def_mem_per_cpu, buffer);
+            safe_unpack64(&build_ptr->debug_flags, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->dependency_params,
+                                &uint32_tmp, buffer);
+
+            safe_unpack16(&build_ptr->eio_timeout, buffer);
+            safe_unpack16(&build_ptr->enforce_part_limits, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->epilog, &uint32_tmp,
+                                buffer);
+            safe_unpack32(&build_ptr->epilog_msg_time, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->epilog_slurmctld,
+                                &uint32_tmp, buffer);
+
+            if (unpack_key_pair_list(&build_ptr->ext_sensors_conf,
+                                    protocol_version, buffer)
+                != SLURM_SUCCESS)
+                goto unpack_error;
+
+            safe_unpackstr_xmalloc(&build_ptr->ext_sensors_type,
+                                &uint32_tmp, buffer);
+            safe_unpack16(&build_ptr->ext_sensors_freq, buffer);
+
+            safe_unpackstr_xmalloc(&build_ptr->fed_params, &uint32_tmp,
+                                buffer);
+            safe_unpack32(&build_ptr->first_job_id, buffer);
+            safe_unpack16(&build_ptr->fs_dampening_factor, buffer);
+
+            safe_unpack16(&build_ptr->get_env_timeout, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->gres_plugins,
+                                &uint32_tmp, buffer);
+            safe_unpack16(&build_ptr->group_time, buffer);
+            safe_unpack16(&build_ptr->group_force, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->gpu_freq_def,
+                                &uint32_tmp, buffer);
+
+            safe_unpack32(&build_ptr->hash_val, buffer);
+
+            safe_unpack16(&build_ptr->health_check_interval, buffer);
+            safe_unpack16(&build_ptr->health_check_node_state, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->health_check_program,
+                                &uint32_tmp, buffer);
+
+            safe_unpack16(&build_ptr->inactive_limit, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->interactive_step_opts,
+                                &uint32_tmp, buffer);
+
+            safe_unpackstr_xmalloc(&build_ptr->job_acct_gather_freq,
+                                &uint32_tmp, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->job_acct_gather_type,
+                                &uint32_tmp, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->job_acct_gather_params,
+                                &uint32_tmp, buffer);
+
+            safe_unpackstr_xmalloc(&build_ptr->job_comp_host,
+                                &uint32_tmp, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->job_comp_loc,
+                                &uint32_tmp, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->job_comp_params,
+                                &uint32_tmp, buffer);
+            safe_unpack32(&build_ptr->job_comp_port, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->job_comp_type,
+                                &uint32_tmp, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->job_comp_user,
+                                &uint32_tmp, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->job_container_plugin,
+                                &uint32_tmp, buffer);
+
+            safe_unpackstr_xmalloc(&build_ptr->job_credential_private_key,
+                                &uint32_tmp, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->
+                                job_credential_public_certificate,
+                                &uint32_tmp, buffer);
+            if (slurm_unpack_list(&build_ptr->job_defaults_list,
+                                job_defaults_unpack, xfree_ptr,
+                                buffer,protocol_version) != SLURM_SUCCESS)
+                goto unpack_error;
+            safe_unpack16(&build_ptr->job_file_append, buffer);
+            safe_unpack16(&build_ptr->job_requeue, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->job_submit_plugins,
+                                &uint32_tmp, buffer);
+
+            safe_unpack16(&build_ptr->kill_on_bad_exit, buffer);
+            safe_unpack16(&build_ptr->kill_wait, buffer);
+
+            safe_unpackstr_xmalloc(&build_ptr->launch_params,
+                                &uint32_tmp, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->launch_type,
+                                &uint32_tmp, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->licenses,
+                                &uint32_tmp, buffer);
+            safe_unpack16(&build_ptr->log_fmt, buffer);
+
+            safe_unpack32(&build_ptr->max_array_sz, buffer);
+            safe_unpack32(&build_ptr->max_dbd_msgs, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->mail_domain,
+                                &uint32_tmp, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->mail_prog,
+                                &uint32_tmp, buffer);
+            safe_unpack32(&build_ptr->max_job_cnt, buffer);
+            safe_unpack32(&build_ptr->max_job_id, buffer);
+            safe_unpack64(&build_ptr->max_mem_per_cpu, buffer);
+            safe_unpack32(&build_ptr->max_node_cnt, buffer);
+            safe_unpack32(&build_ptr->max_step_cnt, buffer);
+            safe_unpack16(&build_ptr->max_tasks_per_node, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->mcs_plugin,
+                                &uint32_tmp, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->mcs_plugin_params,
+                                &uint32_tmp, buffer);
+            safe_unpack32(&build_ptr->min_job_age, buffer);
+            if (unpack_key_pair_list(&build_ptr->mpi_conf, protocol_version,
+                        buffer) != SLURM_SUCCESS)
+                goto unpack_error;
+            safe_unpackstr_xmalloc(&build_ptr->mpi_default,
+                                &uint32_tmp, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->mpi_params,
+                                &uint32_tmp, buffer);
+            safe_unpack16(&build_ptr->msg_timeout, buffer);
+
+            safe_unpack32(&build_ptr->next_job_id, buffer);
+
+            if (unpack_config_plugin_params_list(
+                    &build_ptr->node_features_conf,
+                    protocol_version, buffer) != SLURM_SUCCESS)
+                goto unpack_error;
+
+            safe_unpackstr_xmalloc(&build_ptr->node_features_plugins,
+                                &uint32_tmp, buffer);
+
+            safe_unpackstr_xmalloc(&build_ptr->node_prefix,
+                                &uint32_tmp, buffer);
+
+            safe_unpack16(&build_ptr->over_time_limit, buffer);
+
+            safe_unpackstr_xmalloc(&build_ptr->plugindir,
+                                &uint32_tmp, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->plugstack,
+                                &uint32_tmp, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->power_parameters,
+                                &uint32_tmp, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->power_plugin,
+                                &uint32_tmp, buffer);
+
+            safe_unpack16(&build_ptr->preempt_mode, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->preempt_type,
+                                &uint32_tmp, buffer);
+            safe_unpack32(&build_ptr->preempt_exempt_time, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->prep_params,
+                                &uint32_tmp, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->prep_plugins,
+                                &uint32_tmp, buffer);
+
+            safe_unpack32(&build_ptr->priority_decay_hl, buffer);
+            safe_unpack32(&build_ptr->priority_calc_period, buffer);
+            safe_unpack16(&build_ptr->priority_favor_small, buffer);
+            safe_unpack16(&build_ptr->priority_flags, buffer);
+            safe_unpack32(&build_ptr->priority_max_age, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->priority_params, &uint32_tmp,
+                                buffer);
+            safe_unpack16(&build_ptr->priority_reset_period, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->priority_type, &uint32_tmp,
+                                buffer);
+            safe_unpack32(&build_ptr->priority_weight_age, buffer);
+            safe_unpack32(&build_ptr->priority_weight_assoc, buffer);
+            safe_unpack32(&build_ptr->priority_weight_fs, buffer);
+            safe_unpack32(&build_ptr->priority_weight_js, buffer);
+            safe_unpack32(&build_ptr->priority_weight_part, buffer);
+            safe_unpack32(&build_ptr->priority_weight_qos, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->priority_weight_tres,
+                                &uint32_tmp, buffer);
+
+            safe_unpack16(&build_ptr->private_data, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->proctrack_type, &uint32_tmp,
+                                buffer);
+            safe_unpackstr_xmalloc(&build_ptr->prolog, &uint32_tmp,
+                                buffer);
+            safe_unpack16(&build_ptr->prolog_epilog_timeout, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->prolog_slurmctld,
+                                &uint32_tmp, buffer);
+            safe_unpack16(&build_ptr->prolog_flags, buffer);
+            safe_unpack16(&build_ptr->propagate_prio_process, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->propagate_rlimits,
+                                &uint32_tmp, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->propagate_rlimits_except,
+                                &uint32_tmp, buffer);
+
+            safe_unpackstr_xmalloc(&build_ptr->reboot_program, &uint32_tmp,
+                                buffer);
+            safe_unpack16(&build_ptr->reconfig_flags, buffer);
+
+            safe_unpackstr_xmalloc(&build_ptr->requeue_exit,
+                                &uint32_tmp, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->requeue_exit_hold,
+                                &uint32_tmp, buffer);
+
+            safe_unpackstr_xmalloc(&build_ptr->resume_fail_program,
+                                &uint32_tmp, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->resume_program,
+                                &uint32_tmp, buffer);
+            safe_unpack16(&build_ptr->resume_rate, buffer);
+            safe_unpack16(&build_ptr->resume_timeout, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->resv_epilog, &uint32_tmp,
+                                buffer);
+            safe_unpack16(&build_ptr->resv_over_run, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->resv_prolog, &uint32_tmp,
+                                buffer);
+            safe_unpack16(&build_ptr->ret2service, buffer);
+
+            safe_unpackstr_xmalloc(&build_ptr->route_plugin,
+                                &uint32_tmp, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->sched_params,
+                                &uint32_tmp, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->sched_logfile,
+                                &uint32_tmp, buffer);
+            safe_unpack16(&build_ptr->sched_log_level, buffer);
+            safe_unpack16(&build_ptr->sched_time_slice, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->schedtype,
+                                &uint32_tmp, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->scron_params,
+                                &uint32_tmp, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->select_type,
+                                &uint32_tmp, buffer);
+
+            if (unpack_key_pair_list(&build_ptr->select_conf_key_pairs,
+                                    protocol_version, buffer)
+                != SLURM_SUCCESS)
+                goto unpack_error;
+
+            safe_unpack16(&build_ptr->select_type_param, buffer);
+
+            safe_unpackstr_xmalloc(&build_ptr->slurm_conf,
+                                &uint32_tmp, buffer);
+            safe_unpack32(&build_ptr->slurm_user_id, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->slurm_user_name,
+                                &uint32_tmp, buffer);
+            safe_unpack32(&build_ptr->slurmd_user_id, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->slurmd_user_name,
+                                &uint32_tmp, buffer);
+
+            safe_unpackstr_xmalloc(&build_ptr->slurmctld_addr,
+                                &uint32_tmp, buffer);
+            safe_unpack16(&build_ptr->slurmctld_debug, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->slurmctld_logfile,
+                                &uint32_tmp, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->slurmctld_params,
+                                &uint32_tmp, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->slurmctld_pidfile,
+                                &uint32_tmp, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->slurmctld_plugstack,
+                                &uint32_tmp, buffer);
+            if (unpack_config_plugin_params_list(
+                    &build_ptr->slurmctld_plugstack_conf,
+                    protocol_version, buffer) != SLURM_SUCCESS)
+                goto unpack_error;
+            safe_unpack32(&build_ptr->slurmctld_port, buffer);
+            safe_unpack16(&build_ptr->slurmctld_port_count, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->slurmctld_primary_off_prog,
+                                &uint32_tmp, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->slurmctld_primary_on_prog,
+                                &uint32_tmp, buffer);
+            safe_unpack16(&build_ptr->slurmctld_syslog_debug, buffer);
+            safe_unpack16(&build_ptr->slurmctld_timeout, buffer);
+
+            safe_unpack16(&build_ptr->slurmd_debug, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->slurmd_logfile, &uint32_tmp,
+                                buffer);
+            safe_unpackstr_xmalloc(&build_ptr->slurmd_params, &uint32_tmp,
+                                buffer);
+            safe_unpackstr_xmalloc(&build_ptr->slurmd_pidfile, &uint32_tmp,
+                                buffer);
+            safe_unpack32(&build_ptr->slurmd_port, buffer);
+
+            safe_unpackstr_xmalloc(&build_ptr->slurmd_spooldir,
+                                &uint32_tmp, buffer);
+            safe_unpack16(&build_ptr->slurmd_syslog_debug, buffer);
+            safe_unpack16(&build_ptr->slurmd_timeout, buffer);
+
+            safe_unpackstr_xmalloc(&build_ptr->srun_epilog,
+                                &uint32_tmp, buffer);
+
+            build_ptr->srun_port_range = xcalloc(2, sizeof(uint16_t));
+            safe_unpack16(&build_ptr->srun_port_range[0], buffer);
+            safe_unpack16(&build_ptr->srun_port_range[1], buffer);
+
+            safe_unpackstr_xmalloc(&build_ptr->srun_prolog,
+                                &uint32_tmp, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->state_save_location,
+                                &uint32_tmp, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->suspend_exc_nodes,
+                                &uint32_tmp, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->suspend_exc_parts,
+                                &uint32_tmp, buffer);
+
+            safe_unpackstr_xmalloc(&build_ptr->suspend_program,
+                                &uint32_tmp, buffer);
+            safe_unpack16(&build_ptr->suspend_rate, buffer);
+            safe_unpack32(&build_ptr->suspend_time, buffer);
+            safe_unpack16(&build_ptr->suspend_timeout, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->switch_param,
+                                &uint32_tmp, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->switch_type,
+                                &uint32_tmp, buffer);
+
+            safe_unpackstr_xmalloc(&build_ptr->task_epilog,
+                                &uint32_tmp, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->task_prolog,
+                                &uint32_tmp, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->task_plugin,
+                                &uint32_tmp, buffer);
+            safe_unpack32(&build_ptr->task_plugin_param, buffer);
+            safe_unpack16(&build_ptr->tcp_timeout, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->tmp_fs, &uint32_tmp,
+                                buffer);
+            safe_unpackstr_xmalloc(&build_ptr->topology_param,
+                                &uint32_tmp, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->topology_plugin,
+                                &uint32_tmp, buffer);
+            safe_unpack16(&build_ptr->tree_width, buffer);
+
+            safe_unpackstr_xmalloc(&build_ptr->unkillable_program,
+                                &uint32_tmp, buffer);
+            safe_unpack16(&build_ptr->unkillable_timeout, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->version,
+                                &uint32_tmp, buffer);
+            safe_unpack16(&build_ptr->vsize_factor, buffer);
+
+            safe_unpack16(&build_ptr->wait_time, buffer);
+            safe_unpackstr_xmalloc(&build_ptr->x11_params,
+                                &uint32_tmp, buffer);
+#ifdef __METASTACK_NEW_SUSPEND_KEEP_IDLE
+            safe_unpack32(&build_ptr->suspend_idle_def, buffer);
+#endif
+#ifdef __METASTACK_OPT_CACHE_QUERY
+            safe_unpack16(&build_ptr->cachedup_interval, buffer);
+            safe_unpack16(&build_ptr->cache_query, buffer);
+            safe_unpack32(&build_ptr->query_port, buffer);
+            safe_unpack16(&build_ptr->query_port_count, buffer);
+			safe_unpack16(&build_ptr->cachedup_abs_realtime, buffer);
+#endif
+#ifdef __METASTACK_OPT_MSG_OUTPUT
+            safe_unpackstr_xmalloc(&build_ptr->extra_msg_file,
+                                &uint32_tmp, buffer);
+#endif
+#ifdef __METASTACK_NEW_RPC_RATE_LIMIT
+            if (unpack_key_pair_list(&build_ptr->rl_config,
+                                    protocol_version, buffer)
+                != SLURM_SUCCESS)
+                goto unpack_error;
+
+            if (unpack_key_pair_list(&build_ptr->rl_users,
+                                    protocol_version, buffer)
+                != SLURM_SUCCESS)
+                goto unpack_error;				
+#endif
+#ifdef __METASTACK_PRIORITY_JOBSIZE
+            safe_unpackstr_xmalloc(&build_ptr->priority_jobsize_maxvalue,
+                                &uint32_tmp, buffer);
+#endif	
+#ifdef __METASTACK_OPT_GRES_CONFIG
+			safe_unpack16(&build_ptr->slurmctld_load_gres, buffer);
+#endif
+		} else if (protocol_version >= META_2_2_PROTOCOL_VERSION) {
                         safe_unpack_time(&build_ptr->last_update, buffer);
 
             safe_unpack16(&build_ptr->accounting_storage_enforce, buffer);

--- a/src/slurmctld/proc_req.c
+++ b/src/slurmctld/proc_req.c
@@ -546,6 +546,9 @@ static void _fill_ctld_conf(slurm_conf_t *conf_ptr)
 		xstrdup(conf->slurmctld_primary_on_prog);
 	conf_ptr->slurmctld_syslog_debug = conf->slurmctld_syslog_debug;
 	conf_ptr->slurmctld_timeout   = conf->slurmctld_timeout;
+#ifdef  __METASTACK_OPT_GRES_CONFIG
+	conf_ptr->slurmctld_load_gres= conf->slurmctld_load_gres;
+#endif
 	conf_ptr->slurmd_debug        = conf->slurmd_debug;
 	conf_ptr->slurmd_logfile      = xstrdup(conf->slurmd_logfile);
 	conf_ptr->slurmd_params	      = xstrdup(conf->slurmd_params);

--- a/src/slurmctld/read_config.c
+++ b/src/slurmctld/read_config.c
@@ -50,6 +50,9 @@
 #include <sys/types.h>
 #include <time.h>
 #include <unistd.h>
+#ifdef  __METASTACK_OPT_GRES_CONFIG
+#include <sys/time.h>
+#endif
 
 #include "src/common/assoc_mgr.h"
 #include "src/common/cpu_frequency.h"
@@ -71,6 +74,9 @@
 #include "src/common/switch.h"
 #include "src/common/xstring.h"
 #include "src/common/cgroup.h"
+#ifdef  __METASTACK_OPT_GRES_CONFIG
+#include "src/common/parse_config.h"
+#endif
 
 #include "src/slurmctld/acct_policy.h"
 #include "src/slurmctld/burst_buffer.h"
@@ -2624,6 +2630,105 @@ extern void update_feature_list(List feature_list, char *new_features,
 	node_features_updated = true;
 }
 
+#ifdef __METASTACK_OPT_GRES_CONFIG
+/**
+ * Removes parentheses and their contents from a given string.
+ * str IN - The input string to be modified.
+ */
+static void remove_parentheses(char *str) {
+	if (str == NULL) {
+		return; 
+	}
+	char *src, *dst;
+	src = dst = str; 
+	while (*src != '\0') { 
+		if (*src != '(') { 
+			*dst++ = *src; 
+			src++; 
+		} else { 
+			src++; 
+			while (*src != '\0' && *src != ')') {
+				src++;
+			}
+			if (*src == ')') { 
+				src++; 
+			}
+		}
+	}
+	*dst = '\0'; 
+}
+
+/**
+ * Parses the GRES count from a given GRES name string.
+ * 
+ * This function takes a GRES name string, removes any parentheses and their contents,
+ * and then parses the count of GRES resources. It assumes the GRES name is in the format
+ * "type:count" and can contain multiple entries separated by commas.
+ * gres_name IN - The GRES name string to parse.
+ * return - The total count of GRES resources.
+ */
+static int parse_gres_count(const char *gres_name) {
+	if (gres_name == NULL) {
+		error("GRES name is NULL");
+		return -1;  
+	}
+	char *gres_copy = strdup(gres_name);
+	if (!gres_copy) {
+		error("Memory allocation failed");
+		return -1;
+	}
+	remove_parentheses(gres_copy);
+	char *token = strtok(gres_copy, ",");
+	int total_count = 0;
+
+	while (token != NULL) {
+		char *last_colon = strrchr(token, ':');
+		if (last_colon != NULL) {
+			char *endptr;
+			long num = strtol(last_colon + 1, &endptr, 10);
+			if (*endptr == '\0' && endptr > last_colon + 1) {
+				total_count += (int)num;
+			} else {
+				error("Failed to parse GRES number from gres_name");
+			}
+		} else {
+			error("No colon found in gres_name");
+		}
+		token = strtok(NULL, ",");
+	}
+
+	free(gres_copy);
+	return total_count;
+}
+/**
+* Cleans up and frees memory allocated within each element of a parsed lines array.
+*
+* This function iterates through each element of the parsed_lines array and frees
+* the memory allocated for the key, value, and new_leftover fields.  It also destroys
+* any associated hash table and host list.
+*
+* parsed_lines IN - Array of parsed lines to be cleaned up.
+* max_parsed_lines IN - Number of elements in the parsed_lines array.
+*/
+static void cleanup_parsed_lines(parsed_line_t *parsed_lines, int max_parsed_lines) {
+	if (parsed_lines == NULL || max_parsed_lines < 0) {
+		return; 
+	}
+	for (int i = 0; i < max_parsed_lines; i++) {
+		xfree(parsed_lines[i].key);
+		xfree(parsed_lines[i].value);
+		xfree(parsed_lines[i].new_leftover);
+		if (parsed_lines[i].hashtbl) {
+			s_p_hashtbl_destroy(parsed_lines[i].hashtbl); 
+		}
+		if (parsed_lines[i].hostlist) {
+			hostlist_destroy(parsed_lines[i].hostlist); 
+		}
+	}
+	xfree(parsed_lines);
+}
+#endif
+
 static void _gres_reconfig(bool reconfig)
 {
 	node_record_t *node_ptr;
@@ -2636,34 +2741,119 @@ static void _gres_reconfig(bool reconfig)
 		goto grab_includes;
 	}
 
-	for (i = 0; (node_ptr = next_node(&i)); i++) {
-		if (node_ptr->gres)
-			gres_name = node_ptr->gres;
-		else
-			gres_name = node_ptr->config_ptr->gres;
-		gres_init_node_config(gres_name, &node_ptr->gres_list);
-		if (!IS_NODE_CLOUD(node_ptr))
-			continue;
+#ifdef __METASTACK_OPT_GRES_CONFIG
+	struct timeval start, end;
+	long seconds, useconds;
+	double mtime;
+	if(slurm_conf.slurmctld_load_gres){
+		int gres_number = -1;
+		int max_parsed_lines = 0;
+		int num_parsed_lines = 0;
+		char *gres_conf_file = NULL;
+		FILE *fg;
+		char ch;
+		gettimeofday(&start, NULL);
+		gres_conf_file = get_extra_conf_path("gres.conf");
+		fg = fopen(gres_conf_file, "r");
+		if (fg == NULL) {
+			error("_gres_reconfig: unable to read \"%s\": %m", gres_conf_file);
+			xfree(gres_conf_file);
+			return ;
+		}	
+		while ((ch = fgetc(fg)) != EOF) {
+			if (ch == '\n') {
+				max_parsed_lines++;
+			}
+		}
+		/* If the file is not empty and the last character is not a newline, increase the number of lines */
+		if (fseek(fg, 0, SEEK_END) == 0) {
+			if (ftell(fg) > 0) {
+				max_parsed_lines++;
+			}
+		}
+		max_parsed_lines++;
+		fclose(fg);
+		parsed_lines = xmalloc(sizeof(parsed_line_t) * max_parsed_lines);
+		if (parsed_lines == NULL) {
+			error("_gres_reconfig:Memory allocation failed");
+			return;
+		}
+		s_p_hashtbl_t *tbl;
+		tbl = gres_parse_config_file(gres_conf_file, parsed_lines, max_parsed_lines, &num_parsed_lines);
+		if (!tbl) {
+			error("Failed to parse GRES configuration file");
+			xfree(gres_conf_file); 
+			return;
+		}
+		xfree(gres_conf_file);
+		s_p_hashtbl_destroy(tbl);
+		for (i = 0; (node_ptr = next_node(&i)); i++) {
+			if (node_ptr->gres){
+				gres_name = node_ptr->gres;
+			}
+			else{
+				gres_name = node_ptr->config_ptr->gres;
+			}
+			if (gres_name == NULL) {
+				continue;
+			}
+			gres_number = parse_gres_count(gres_name);
+			gres_init_node_config(gres_name, &node_ptr->gres_list);
+			if(gres_g_node_config_loadgres(
+							node_ptr->config_ptr->cpus, node_ptr->name,
+							node_ptr->gres_list, NULL, NULL, parsed_lines, gres_number) ==SLURM_ERROR){
+				continue;
+			}	
+			gres_node_config_validate(
+				node_ptr->name, node_ptr->config_ptr->gres,
+				&node_ptr->gres, &node_ptr->gres_list,
+				node_ptr->config_ptr->threads,
+				node_ptr->config_ptr->cores,
+				node_ptr->config_ptr->tot_sockets,
+				slurm_conf.conf_flags & CTL_CONF_OR, NULL);
 
-		/*
-		 * Load in GRES for node now. By default Slurm gets this
-		 * information when the node registers for the first
-		 * time, which can take a while for a node in the cloud
-		 * to boot.
-		 */
-		gres_g_node_config_load(
-			node_ptr->config_ptr->cpus, node_ptr->name,
-			node_ptr->gres_list, NULL, NULL);
-		gres_node_config_validate(
-			node_ptr->name, node_ptr->config_ptr->gres,
-			&node_ptr->gres, &node_ptr->gres_list,
-			node_ptr->config_ptr->threads,
-			node_ptr->config_ptr->cores,
-			node_ptr->config_ptr->tot_sockets,
-			slurm_conf.conf_flags & CTL_CONF_OR, NULL);
+			gres_loaded = true;
+		}
+		if (parsed_lines != NULL) {
+			cleanup_parsed_lines(parsed_lines, max_parsed_lines);
+		}
+		gettimeofday(&end, NULL);
+		seconds = end.tv_sec - start.tv_sec;
+		useconds = end.tv_usec - start.tv_usec;
+		mtime = (seconds * 1000) + (useconds / 1000.0);
+		debug("Slurmctld load Gres config time: %.2f ms\n", mtime);
+	}else{
+		for (i = 0; (node_ptr = next_node(&i)); i++) {
+			if (node_ptr->gres)
+				gres_name = node_ptr->gres;
+			else
+				gres_name = node_ptr->config_ptr->gres;
+			gres_init_node_config(gres_name, &node_ptr->gres_list);
+			if (!IS_NODE_CLOUD(node_ptr))
+				continue;
 
-		gres_loaded = true;
+			/*
+			 * Load in GRES for node now. By default Slurm gets this
+			 * information when the node registers for the first
+			 * time, which can take a while for a node in the cloud
+			 * to boot.
+			 */
+			gres_g_node_config_load(
+				node_ptr->config_ptr->cpus, node_ptr->name,
+				node_ptr->gres_list, NULL, NULL);
+			
+			gres_node_config_validate(
+				node_ptr->name, node_ptr->config_ptr->gres,
+				&node_ptr->gres, &node_ptr->gres_list,
+				node_ptr->config_ptr->threads,
+				node_ptr->config_ptr->cores,
+				node_ptr->config_ptr->tot_sockets,
+				slurm_conf.conf_flags & CTL_CONF_OR, NULL);
+
+			gres_loaded = true;
+		}		
 	}
+#endif
 
 grab_includes:
 	if (!gres_loaded) {


### PR DESCRIPTION
In a cluster, if node A goes offline (with a status of down or unknown), and the slurmctld service is restarted at this time, the GRES information in memory will be lost, causing jobs that do not conform to the GRES card-core binding relationship to be submitted to the system, resulting in the jobs remaining in the queue indefinitely.
Solution: When the management node service starts, the gres.conf configuration should be pre-loaded into memory, and this information should be updated again when the compute nodes register.